### PR TITLE
#163383131 Add test coverage from codeclimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,12 @@ node_js:
   - "11.10.1"
 cache:
   directories:
-  - node_modules
+    - node_modules
+before_script:
+  - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+  - chmod +x ./cc-test-reporter
+  - ./cc-test-reporter before-build
 script:
   - npm run coverage
+after_script:
+  - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 [![Build Status](https://travis-ci.org/andela/ah-frontend-summer.svg?branch=develop)](https://travis-ci.org/andela/ah-frontend-summer)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/0fd3fdfadcf03f756fe1/test_coverage)](https://codeclimate.com/github/andela/ah-frontend-summer/test_coverage)
+[![Maintainability](https://api.codeclimate.com/v1/badges/0fd3fdfadcf03f756fe1/maintainability)](https://codeclimate.com/github/andela/ah-frontend-summer/maintainability)
 
 # Authors Heaven

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "coverage": "react-scripts test --env=jsdom --coverage --coveragePathIgnorePatterns=src/[index.jsx,serviceWorker.js]"
+    "coverage": "react-scripts test --env=jsdom --coverage --coveragePathIgnorePatterns=src/index.jsx --coveragePathIgnorePatterns=src/serviceWorker.js"
   },
   "browserslist": [
     ">0.2%",


### PR DESCRIPTION
**Description**
After tests have run with travis a report is sent to codeclimate about the test coverage.

**Type of change**
Not a feature change simply keeps developers aware of how much of their code have they tested

**Relevant stories**
[#163383131](https://www.pivotaltracker.com/n/projects/2240000/stories/163383131)